### PR TITLE
Corect Version tag

### DIFF
--- a/Fody/ModuleWeaver.cs
+++ b/Fody/ModuleWeaver.cs
@@ -106,6 +106,8 @@ public class ModuleWeaver
             assemblyInfoVersion = ReplaceVersion3rd(assemblyInfoVersion, ver.Revision);
             VerifyStartsWithVersion(assemblyInfoVersion);
             customAttribute.ConstructorArguments[0] = new CustomAttributeArgument(ModuleDefinition.TypeSystem.String, assemblyInfoVersion);
+            
+            ModuleDefinition.Assembly.Name.Version = new Version(assemblyInfoVersion);
         }
         else
         {
@@ -126,8 +128,7 @@ public class ModuleWeaver
 
             assemblyInfoVersion = ReplaceVersion3rd(assemblyInfoVersion, ver.Revision);
 
-            customAttribute.ConstructorArguments.Add(new CustomAttributeArgument(ModuleDefinition.TypeSystem.String, assemblyInfoVersion));
-            customAttributes.Add(customAttribute);
+            ModuleDefinition.Assembly.Name.Version = new Version(assemblyInfoVersion);
         }
         LogInfo("AssemblyVersionAttribute processed.");
 


### PR DESCRIPTION
Rename the assembly version tag, not the attribute (same info for .NET)
